### PR TITLE
chore: remove npm publish metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,45 +98,6 @@ jobs:
             ghcr.io/agynio/docker-runner:${{ env.RELEASE_VERSION }}
             ghcr.io/agynio/docker-runner:latest
 
-  npm-publish:
-    name: Publish npm package
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    needs: image-release
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.5.0
-          run_install: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: '20'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@agyn'
-
-      - name: Install Buf CLI
-        uses: bufbuild/buf-setup-action@v1
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Generate protobufs
-        run: pnpm proto:generate
-
-      - name: Build
-        run: pnpm build
-
-      - name: Publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pnpm publish --no-git-checks
-
   chart:
     name: Package and publish Helm chart
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@agyn/docker-runner",
   "version": "0.1.0",
+  "private": true,
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
@@ -29,19 +30,5 @@
     "typescript-eslint": "^8.8.1",
     "vitest": "^3.2.4"
   },
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/agynio/docker-runner.git"
-  },
-  "files": [
-    "src/**/*.ts",
-    "dist/**",
-    "package.json",
-    "tsconfig.json",
-    "buf.gen.yaml"
-  ],
   "packageManager": "pnpm@10.5.0"
 }


### PR DESCRIPTION
## Summary
- remove npm publish job from release workflow
- mark package private and drop npm publishing metadata

## Testing
- pnpm lint
- pnpm test

Fixes #3