### PR TITLE
docs: add devspace commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,19 @@ It also forwards gRPC on port `50051` to your local machine.
 
 ## Running Tests
 
+Keep `devspace dev` running in another terminal, then use:
+
 ```sh
-devspace enter
-pnpm test
-DOCKER_RUNNER_SHARED_SECRET=change-me pnpm test:e2e
+devspace run test
+devspace run test:e2e
+devspace run enter
 ```
 
-`pnpm test` runs unit + integration tests; the integration suite requires
-Docker, provided by the DinD sidecar in the dev pod. The e2e suite requires the
-shared secret env var shown above.
+`devspace run test` runs unit + integration tests; the integration suite
+requires Docker, provided by the DinD sidecar in the dev pod. `devspace run
+test:e2e` runs the e2e suite, with `DOCKER_RUNNER_SHARED_SECRET` already
+provided by the Helm deployment. `devspace run enter` opens an interactive shell
+in the dev container.
 
 ## Troubleshooting
 

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -3,6 +3,26 @@ version: v2beta1
 vars:
   DOCKER_RUNNER_NAMESPACE: platform
 
+commands:
+  test: |-
+    exec_container \
+      --label-selector "app.kubernetes.io/name=docker-runner,app.kubernetes.io/instance=docker-runner" \
+      --container docker-runner \
+      -n ${DOCKER_RUNNER_NAMESPACE} \
+      -- pnpm test
+  test:e2e: |-
+    exec_container \
+      --label-selector "app.kubernetes.io/name=docker-runner,app.kubernetes.io/instance=docker-runner" \
+      --container docker-runner \
+      -n ${DOCKER_RUNNER_NAMESPACE} \
+      -- pnpm test:e2e
+  enter: |-
+    exec_container \
+      --label-selector "app.kubernetes.io/name=docker-runner,app.kubernetes.io/instance=docker-runner" \
+      --container docker-runner \
+      -n ${DOCKER_RUNNER_NAMESPACE} \
+      -- sh
+
 pipelines:
   dev: |-
     if kubectl get application docker-runner -n argocd >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- add devspace commands for test, test:e2e, and enter
- update README to reference devspace run commands and in-cluster env setup

## Testing
- pnpm lint
- pnpm test

Closes #9